### PR TITLE
board-firmware: fix the description.

### DIFF
--- a/recipes-bsp/board-firmware/board-firmware_1.4.bb
+++ b/recipes-bsp/board-firmware/board-firmware_1.4.bb
@@ -1,7 +1,7 @@
 
 
 COMPATIBLE_MACHINE = "morello"
-SUMMARY            = "$DESCRIPTION"
+SUMMARY            = "Board firmware for Morello"
 DESCRIPTION        = "The SD card image from ARM that contains non compile-able binaries."
 HOMEPAGE           = "https://git.morello-project.org/morello/board-firmware"
 LICENSE            = "STMicroelectronics&BSD-3 & BDS-2"


### PR DESCRIPTION
a) it was a copy paste error b) it should not be equal to summary

Signed-off-by: Pawel Zalewski <pzalewski@thegoodpenguin.co.uk>